### PR TITLE
add type to client.SOCKET

### DIFF
--- a/example.js
+++ b/example.js
@@ -1,7 +1,0 @@
-import msgroomBot from "./index.js";
-const bot = new msgroomBot
-
-await bot.connect("msgroom-bot")
-await bot.send("Hello! This is msgroom-bot made by its-pablo. If you are seeing this, everything is working properly. Try not to run this file many times because staff doesn't like spam.")
-bot.send("Example bot has connected!")
-console.log("done")

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "GPL-2.0",
       "dependencies": {
-        "socket.io-client": "^4.6.1"
+        "socket.io-client": "^4.6.1",
+        "typescript": "^5.0.3"
       }
     },
     "node_modules/@socket.io/component-emitter": {
@@ -102,6 +103,18 @@
       },
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.3.tgz",
+      "integrity": "sha512-xv8mOEDnigb/tN9PSMTwSEqAnUvkoXMQlicOb0IUVDBSQCgBSaAAROUZYy2IcUy5qU6XajK5jjjO7TMWqBTKZA==",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=12.20"
       }
     },
     "node_modules/xmlhttprequest-ssl": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "1.0.0",
       "license": "GPL-2.0",
       "dependencies": {
-        "socket.io-client": "^4.6.1",
+        "socket.io-client": "^4.6.1"
+      },
+      "devDependencies": {
         "typescript": "^5.0.3"
       }
     },
@@ -109,6 +111,7 @@
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.3.tgz",
       "integrity": "sha512-xv8mOEDnigb/tN9PSMTwSEqAnUvkoXMQlicOb0IUVDBSQCgBSaAAROUZYy2IcUy5qU6XajK5jjjO7TMWqBTKZA==",
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
   "license": "GPL-2.0",
   "type": "module",
   "dependencies": {
-    "socket.io-client": "^4.6.1",
+    "socket.io-client": "^4.6.1"
+  },
+  "devDependencies": {
     "typescript": "^5.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "license": "GPL-2.0",
   "type": "module",
   "dependencies": {
-    "socket.io-client": "^4.6.1"
+    "socket.io-client": "^4.6.1",
+    "typescript": "^5.0.3"
   }
 }

--- a/src/example.js
+++ b/src/example.js
@@ -1,0 +1,10 @@
+import msgroomBot from "./index.js";
+const bot = new msgroomBot
+
+await bot.connect("msgroom-bot")
+
+bot
+    .send("Hello! This is msgroom-bot made by its-pablo. If you are seeing this, everything is working properly. Try not to run this file many times because staff doesn't like spam.")
+    .send("Example bot has connected!")
+
+console.log("done")

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import { io } from "socket.io-client"
+import MsgroomSocket from "./types.js"
 
 export class CommandSet {
     constructor(prefix) {
@@ -18,6 +19,11 @@ export class Command {
     }
 }
 export default class {
+    /**
+     * @type {MsgroomSocket}
+     */
+    SOCKET
+
     constructor() {
     }
     /**
@@ -26,7 +32,7 @@ export default class {
      * @param {URL} url URL of the bot to connect to. Leave blank for default Windows 96 msgroom
      */
     connect(nick, url = new URL("wss://windows96.net:4096")) {
-        this.SOCKET = new io(url.href)
+        this.SOCKET = io(url.href)
         return new Promise((resolve, reject) => {
             this.SOCKET.emit("auth", { user: nick })
             this.SOCKET.on("auth-complete", userId => {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,0 +1,110 @@
+import { Socket } from "socket.io-client";
+
+
+type MsgroomSocket = Socket<ServerToClientEvents, ClientToServerEvents>;
+export default MsgroomSocket;
+
+/**
+ * Hexadecimal color string
+ * @example "#ff0000"
+ */
+export type hexColor = `#${string}`;
+
+export type flag = "staff" | "bot";
+
+interface User {
+    color: hexColor;
+    flags: flag[];
+    id: string;
+    session_id: string;
+    user: string;
+}
+
+
+/**
+ * used for receiving events from the server
+ */
+export interface ServerToClientEvents {
+    "auth-complete": (userID: string) => void;
+    
+    message: (message: {
+        color: hexColor;
+        content: string;
+        date: string;
+        id: string;
+        session_id: string;
+        type: "text";
+        user: string
+    }) => void;
+    
+    "sys-message": (message: {
+        message: string;
+        type: "info" | "error" | "success"
+        isHtml: boolean;
+    }) => void;
+    
+    "nick-changed": (args: {
+        oldUser: string;
+        newUser: string;
+        id: string;
+        session_id: string;
+    }) => void;
+    
+    "user-join": (args: User) => void;
+    
+    "user-leave": (args: {
+        id: string;
+        session_id: string;
+        user: string;
+    }) => void;
+    
+    "user-update": (args: {
+        type: "tag-add";
+        tag?: "staff" | string;
+        tagLabel?: string;
+        user: string
+    }) => void;
+    
+    online: (members: User[]) => void;
+    
+    "auth-error": (error: {
+        reason: string;
+    }) => void;
+    
+    "werror": (reason: string) => void;
+}
+
+/**
+ * used to send events to the server
+ */
+export interface ClientToServerEvents {
+    "admin-action": (args: {
+        args: any;
+    }) => void;
+    
+    message: (args: {
+        /**
+         * The type of message, so far I know only text is supported right now.
+         */
+        type: "text";
+        /**
+         * The text message you want to send.
+         */
+        content: string;
+    }) => void;
+    
+    "change-user": (/** The new nickname you want. */newNick: string) => void;
+    
+    online: () => void;
+    
+    auth: (args: {
+        /**
+         * The username you want to use.
+         */
+        user: string;
+        /**
+         * You can request one from ctrlz
+         */
+        apikey?: string;
+    }) => void;
+}

--- a/src/types.js
+++ b/src/types.js
@@ -1,0 +1,2 @@
+// Please ignore this file, it is just here so we can import types from types.d.ts without node complaining
+export default {}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+    "compilerOptions": {
+        "module": "ES2022",
+        "target": "ES2022",
+        "moduleResolution": "node16"
+    },
+    "exclude": [
+        "node_modules",
+        "**/node_modules/*",
+    ],
+    "include": [
+        "src/**/*"
+    ]
+}


### PR DESCRIPTION
Hey there

First of all nice library you're making, it's looking good so far.
I had this file laying around with all the types for a msgroom socket and found this project and thought I'd give it to you.
I can assure you these types are correct, they were even confirmed to be right by ctrlz.
I'm sure they will make your life a bit easier.

Here a list of changes:

- moved all source files into a folder (src/)
- assigned a type to client.SOCKET (because of this you now have autocomplete for event names and other things)
- created tsconfig.json and added typescript as a devDependency to ensure everything works
- cleaned up example.js a bit
- removed the new keyword when initializing client.SOCKET (io() is a factory function, not a class)

I have tested everything and it works